### PR TITLE
Feature/segmented reading form socket

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -1,19 +1,21 @@
 package scutium
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+)
 
-// basePacket represents the basic structure of a data packet,
+// BasicPacket represents the basic structure of a data packet,
 // consisting of a packet identifier (ID) and payload.
 // The ID is stored as a 32-bit integer, and the payload contains the rest of the packet.
-type basePacket struct {
+type BasicPacket struct {
 	ID      uint32
 	Payload []byte
 }
 
 // Parses the package into fields according to its structure
-func parseBasePacket(pkg []byte) *basePacket {
+func parseBasicPacket(pkg []byte) *BasicPacket {
 	pkgID := binary.BigEndian.Uint32(pkg[:4])
 	payload := pkg[4:]
 
-	return &basePacket{ID: pkgID, Payload: payload}
+	return &BasicPacket{ID: pkgID, Payload: payload}
 }

--- a/packet.go
+++ b/packet.go
@@ -8,14 +8,16 @@ import (
 // consisting of a packet identifier (ID) and payload.
 // The ID is stored as a 32-bit integer, and the payload contains the rest of the packet.
 type BasicPacket struct {
+	Length  uint32
 	ID      uint32
 	Payload []byte
 }
 
 // Parses the package into fields according to its structure
 func parseBasicPacket(pkg []byte) *BasicPacket {
-	pkgID := binary.BigEndian.Uint32(pkg[:4])
-	payload := pkg[4:]
+	pkgLength := binary.BigEndian.Uint32(pkg[:4])
+	pkgID := binary.BigEndian.Uint32(pkg[4:8])
+	payload := pkg[8:]
 
-	return &BasicPacket{ID: pkgID, Payload: payload}
+	return &BasicPacket{Length: pkgLength, ID: pkgID, Payload: payload}
 }

--- a/server.go
+++ b/server.go
@@ -9,7 +9,7 @@ import (
 	"net"
 )
 
-type HandlerFunc func(conn net.Conn, payload []byte) error
+type HandlerFunc func(conn net.Conn, pkg BasicPacket) error
 
 type Server struct {
 	addr     string
@@ -81,13 +81,13 @@ func (s *Server) handleConnection(conn net.Conn) {
 		}
 
 		// Unpacking the package
-		pkg := parseBasePacket(buffer[:n])
+		pkg := parseBasicPacket(buffer[:n])
 
 		handler, ok := s.handlers[pkg.ID]
 		if !ok {
 			log.Printf("Получен пакет с неизвестный ID - %d", pkg.ID)
 			continue
 		}
-		go handler(conn, pkg.Payload)
+		go handler(conn, *pkg)
 	}
 }


### PR DESCRIPTION
There are several important changes:
1) `basePacket` has been renamed to `BasicPacket` and is now public.
2) Reading from the socket is now correct; the possibility of packet fragmentation or buffer overflow has been eliminated.
3) The `maxPacketSize` parameter has been added, with a default value of 1 megabyte, to protect the server from DOS and general overloads, and along with it comes a method `SetMaxPacketSize()` that allows the user to set `maxPacketSize`.